### PR TITLE
Feat/generate page제작

### DIFF
--- a/src/app/generate/page.tsx
+++ b/src/app/generate/page.tsx
@@ -1,7 +1,9 @@
+import GenerateTILForm from "@/components/generate/generateTILForm/GenerateTILForm";
+
 const generate =() =>{
     return (
         <div>
-            TIL 생성 페이지
+            <GenerateTILForm/>
         </div>
     )
 

--- a/src/components/commit/commitList/CommitList.scss
+++ b/src/components/commit/commitList/CommitList.scss
@@ -1,34 +1,92 @@
 .commit-list {
-    &__actions {
-      display: flex;
-      justify-content: flex-end;
-      margin-bottom: 1rem;
-      gap: 0.5rem;
+  &__actions {
+    display: flex;
+    justify-content: flex-end;
+    margin-bottom: 1rem;
+    gap: 0.5rem;
+  }
+
+  &__button {
+    background-color: #00b6fa;
+    color: white;
+    font-weight: bold;
+    padding: 0.4rem 1rem;
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+    transition: background-color 0.2s ease, transform 0.2s ease;
+
+    &:hover {
+      background-color: #009fd6;
     }
-  
-    &__button {
+
+    &.error {
+      background-color: #ff4d4f;
+    }
+
+    &.shake {
+      animation: shake 0.3s;
+    }
+  }
+
+  @keyframes shake {
+    0%   { transform: translateX(0); }
+    25%  { transform: translateX(-4px); }
+    50%  { transform: translateX(4px); }
+    75%  { transform: translateX(-4px); }
+    100% { transform: translateX(0); }
+  }
+
+  &.shake {
+    animation: shake 0.3s;
+  }
+
+  &__ul {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    margin-bottom: 70px;
+  }
+
+  &__item {
+    width: 300px;
+    max-width: 300px;
+    padding: 0.5rem 1rem;
+    border-radius: 6px;
+    border: 1px solid #dcdcdc;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.06);
+    margin-bottom: 0.75rem;
+    cursor: pointer;
+    transition: background 0.2s ease;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    font-weight: normal;
+
+    &:hover {
+      background-color: #f0f8ff;
+    }
+
+    &--selected {
       background-color: #00b6fa;
       color: white;
       font-weight: bold;
-      padding: 0.4rem 1rem;
-      border: none;
-      border-radius: 4px;
-      cursor: pointer;
-      transition: background-color 0.2s ease, transform 0.2s ease;
-  
+      border-color: #00b6fa;
+      box-shadow: 0 3px 6px rgba(0, 182, 250, 0.4);
+
       &:hover {
-        background-color: #009fd6;
+        background-color: #00b6fa;
       }
-  
-      &.error {
-        background-color: #ff4d4f;
-      }
-  
-      &.shake {
-        animation: shake 0.3s;
-      }
+
+      
     }
-  
+    &.error {
+      background-color: #ff4d4f;
+    }
+    
+    &.shake {
+      animation: shake 0.3s;
+    }
     @keyframes shake {
       0%   { transform: translateX(0); }
       25%  { transform: translateX(-4px); }
@@ -36,40 +94,5 @@
       75%  { transform: translateX(-4px); }
       100% { transform: translateX(0); }
     }
-  
-    &__ul {
-      list-style: none;
-      padding: 0;
-      margin: 0;
-      margin-bottom: 70px;
-    }
-  
-    &__item {
-      width: 300px;
-      max-width: 300px;
-      padding: 0.5rem 1rem;
-      border-radius: 6px;
-      border: 1px solid #dcdcdc;
-      box-shadow: 0 2px 4px rgba(0, 0, 0, 0.06);
-      margin-bottom: 0.75rem;
-      cursor: pointer;
-      transition: background 0.2s ease;
-  
-      &:hover {
-        background-color: #f0f8ff;
-      }
-  
-      &--selected {
-        background-color: #00b6fa;
-        color: white;
-        font-weight: bold;
-        border-color: #00b6fa;
-        box-shadow: 0 3px 6px rgba(0, 182, 250, 0.4);
-  
-        &:hover {
-          background-color: #00b6fa;
-        }
-      }
-    }
   }
-  
+}

--- a/src/components/commit/commitList/CommitList.scss
+++ b/src/components/commit/commitList/CommitList.scss
@@ -41,6 +41,7 @@
       list-style: none;
       padding: 0;
       margin: 0;
+      margin-bottom: 70px;
     }
   
     &__item {

--- a/src/components/commit/commitList/CommitList.tsx
+++ b/src/components/commit/commitList/CommitList.tsx
@@ -34,12 +34,29 @@ const CommitList = () => {
   const accessToken = useGetAccessToken();
 
   const [selectedIndexes, setSelectedIndexes] = useState<number[]>([]);
+  const [selectedCommits, setSelectedCommits] = useState<string[]>([]);
   const [shake, setShake] = useState(false);
+  const [shakeIndex, setShakeIndex] = useState<number | null>(null);
 
   const toggleSelection = (index: number) => {
-    setSelectedIndexes((prev) =>
-      prev.includes(index) ? prev.filter((i) => i !== index) : [...prev, index]
-    );
+    setSelectedIndexes((prev) => {
+      if (prev.includes(index)) {
+        const next = prev.filter((i) => i !== index);
+        setSelectedCommits(next.map((i) => commitMessages[i]));
+        return next;
+      } 
+      else {
+        if (prev.length >= 5) {
+          console.log("asdf")
+          setShakeIndex(index);
+          setTimeout(() => setShakeIndex(null), 500);
+          return prev;
+        }
+        const next = [...prev, index];
+        setSelectedCommits(next.map((i) => commitMessages[i]));
+        return next;
+      }
+    });
   };
 
   const refreshCommitList = async () => {
@@ -57,17 +74,19 @@ const CommitList = () => {
       const messages = commits.map((commit) => commit.commit_message);
       setCommitMessages(messages);
       setSelectedIndexes([]);
+      setSelectedCommits([]);
     } catch (err) {
       console.error('커밋 새로고침 실패:', err);
     }
   };
 
   const handleGenerateClick = () => {
-    if (!commitMessages || commitMessages.length === 0) {
+    if (selectedCommits.length === 0) {
       setShake(true);
       setTimeout(() => setShake(false), 500);
       return;
     }
+    setCommitMessages(selectedCommits);
     router.push('/generate');
   };
 
@@ -96,10 +115,13 @@ const CommitList = () => {
           {commitMessages.map((message, idx) => (
             <li
               key={idx}
-              className={`commit-list__item ${selectedIndexes.includes(idx) ? 'commit-list__item--selected' : ''}`}
+              className={`commit-list__item
+                ${selectedIndexes.includes(idx) ? 'commit-list__item--selected' : ''}
+                ${shakeIndex === idx ? 'error shake' : ''}
+              `}
               onClick={() => toggleSelection(idx)}
             >
-              <strong>{message}</strong>
+              {message}
             </li>
           ))}
         </ul>

--- a/src/components/commit/commitList/CommitList.tsx
+++ b/src/components/commit/commitList/CommitList.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { useCommitListStore } from '@/store/userCommitListStore';
+import { useSelectedCommitListStore } from '@/store/selectedCommitListStore';
 import { useUserOrganizationStore } from '@/store/userOrganizationStore';
 import { useUserRepositoryStore } from '@/store/userRepositoryStore';
 import { useUserBranchStore } from '@/store/userBranchStore';
@@ -26,12 +27,13 @@ interface CommitDetailResponse {
 const CommitList = () => {
   const router = useRouter();
   const { commitMessages, setCommitMessages } = useCommitListStore();
+  const {selectedCommitMessages, setSelectedCommitMessages} = useSelectedCommitListStore();
+  const { callApi } = useFetch();
+  const accessToken = useGetAccessToken();
   const selectedOrganizaion = useUserOrganizationStore((state) => state.selectedOrganization);
   const selectedRepository = useUserRepositoryStore((state) => state.selectedRepository);
   const selectedDate = useSelectedDateStore((state) => state.selectedDate);
   const selectedBranchName = useUserBranchStore((state) => state.selectedBranch);
-  const { callApi } = useFetch();
-  const accessToken = useGetAccessToken();
 
   const [selectedIndexes, setSelectedIndexes] = useState<number[]>([]);
   const [selectedCommits, setSelectedCommits] = useState<string[]>([]);
@@ -86,7 +88,7 @@ const CommitList = () => {
       setTimeout(() => setShake(false), 500);
       return;
     }
-    setCommitMessages(selectedCommits);
+    setSelectedCommitMessages(selectedCommits);
     router.push('/generate');
   };
 

--- a/src/components/commit/selectDateCalendar/SelectDateCalendar.tsx
+++ b/src/components/commit/selectDateCalendar/SelectDateCalendar.tsx
@@ -34,7 +34,7 @@ const SelectDateCalendar = () => {
     <div className="calendar__header">
       <button onClick={() => setCurrentDate(subYears(currentDate, 1))}>{'<<'}</button>
       <button onClick={() => setCurrentDate(subMonths(currentDate, 1))}>{'<'}</button>
-      <span>{format(selectedDate, 'yyyy년 M월 d일')}</span>
+      <span>{format(currentDate, 'yyyy년 M월')}</span>
       <button onClick={() => setCurrentDate(addMonths(currentDate, 1))}>{'>'}</button>
       <button onClick={() => setCurrentDate(addYears(currentDate, 1))}>{'>>'}</button>
     </div>

--- a/src/components/generate/generateTILForm/GenerateTILForm.scss
+++ b/src/components/generate/generateTILForm/GenerateTILForm.scss
@@ -6,12 +6,30 @@
     gap: 2rem;
     margin-bottom: 4rem;
   
+    &__form {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 1.5rem;
+      width: 85%;
+      margin: 0 auto;
+    }
+  
+    &__label {
+      width: 100%;
+      max-width: 600px; // ✅ label 너비 고정
+      margin: 0 auto;   // ✅ 중앙 정렬
+      font-weight: bold;
+      color: #333;
+      display: flex;
+      flex-direction: column;
+      gap: 0.5rem;
+    }
+  
     &__commits {
       border-radius: 8px;
       padding: 1rem;
       box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
-      max-width: 400px;
-      width: 100%;
     }
   
     &__commits-list {
@@ -30,25 +48,6 @@
       overflow: hidden;
       text-overflow: ellipsis;
       font-weight: normal;
-    }
-  
-    &__form {
-      display: flex;
-      flex-direction: column;
-      align-items: center;
-      gap: 1.5rem;
-      width: 100%;
-      align-self: center;
-    }
-  
-    &__label {
-      width: 100%;
-      align-self: flex-start;
-      font-weight: bold;
-      color: #333;
-      display: flex;
-      flex-direction: column;
-      gap: 0.5rem;
     }
   
     &__input,

--- a/src/components/generate/generateTILForm/GenerateTILForm.scss
+++ b/src/components/generate/generateTILForm/GenerateTILForm.scss
@@ -1,0 +1,118 @@
+.generate {
+    padding: 2rem;
+    padding-top: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 2rem;
+    margin-bottom: 4rem;
+  
+    &__commits {
+      border-radius: 8px;
+      padding: 1rem;
+      box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+      max-width: 400px;
+      width: 100%;
+    }
+  
+    &__commits-list {
+      list-style: none;
+      padding: 0;
+      margin-top: 1rem;
+    }
+  
+    &__commit-item {
+      margin-bottom: 0.5rem;
+      padding: 0.5rem;
+      border: 1px solid #ddd;
+      border-radius: 4px;
+      background: #f9f9f9;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      font-weight: normal;
+    }
+  
+    &__form {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 1.5rem;
+      width: 100%;
+      align-self: center;
+    }
+  
+    &__label {
+      width: 100%;
+      align-self: flex-start;
+      font-weight: bold;
+      color: #333;
+      display: flex;
+      flex-direction: column;
+      gap: 0.5rem;
+    }
+  
+    &__input,
+    &__select {
+      padding: 0.5rem;
+      border: 1px solid #ccc;
+      border-radius: 4px;
+      font-size: 1rem;
+      outline: none;
+  
+      &:focus {
+        border-color: #00b6fa;
+        box-shadow: 0 0 0 2px rgba(0, 182, 250, 0.2);
+      }
+    }
+  
+    &__visibility {
+      display: flex;
+      flex-direction: column;
+      gap: 0.5rem;
+      align-items: flex-start;
+      width: 100%;
+  
+      label {
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+        font-size: 0.95rem;
+  
+        input[type='radio'] {
+          accent-color: #00b6fa;
+        }
+      }
+    }
+  
+    &__visibility-radio {
+      display: flex;
+      flex-direction: column;
+    }
+  
+    &__visibility-radio-label {
+      font-size: 1rem;
+      margin: 0;
+    }
+  
+    &__visibility-radio-desc {
+      font-size: 0.7rem;
+      color: #666;
+      margin: 0;
+    }
+  
+    &__button {
+      background-color: #00b6fa;
+      color: white;
+      border: none;
+      padding: 0.75rem 2rem;
+      border-radius: 8px;
+      font-size: 1rem;
+      cursor: pointer;
+      transition: background-color 0.2s;
+  
+      &:hover {
+        background-color: #009fd6;
+      }
+    }
+  }
+  

--- a/src/components/generate/generateTILForm/GenerateTILForm.scss
+++ b/src/components/generate/generateTILForm/GenerateTILForm.scss
@@ -17,8 +17,8 @@
   
     &__label {
       width: 100%;
-      max-width: 600px; // ✅ label 너비 고정
-      margin: 0 auto;   // ✅ 중앙 정렬
+      max-width: 600px;
+      margin: 0 auto;
       font-weight: bold;
       color: #333;
       display: flex;

--- a/src/components/generate/generateTILForm/GenerateTILForm.tsx
+++ b/src/components/generate/generateTILForm/GenerateTILForm.tsx
@@ -1,0 +1,91 @@
+'use client'
+
+import './GenerateTILForm.scss';
+import { useCommitListStore } from '@/store/userCommitListStore';
+import { useState } from 'react';
+
+const GenerateTILForm = () => {
+  const { commitMessages } = useCommitListStore();
+  const [title, setTitle] = useState('');
+  const [category, setCategory] = useState('풀스택');
+  const [visibility, setVisibility] = useState<'public' | 'private'>('public');
+
+  return (
+    <div className="generate">
+    <form className="generate__form">
+    <label className='generate__label'>
+        선택된 커밋 목록
+      <section className="generate__commits">
+        <ul className="generate__commits-list">
+          {commitMessages.map((msg, index) => (
+              <li key={index} className="generate__commit-item">
+              {msg}
+            </li>
+          ))}
+        </ul>
+      </section>
+      </label>
+
+        <label className="generate__label">
+          TIL 제목
+          <input
+            type="text"
+            maxLength={40}
+            placeholder="TIL 제목을 입력하세요 (최대 40자)"
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            className="generate__input"
+          />
+        </label>
+
+        <label className="generate__label">
+          카테고리
+          <select
+            value={category}
+            onChange={(e) => setCategory(e.target.value)}
+            className="generate__select"
+          >
+            <option value="풀스택">풀스택</option>
+            <option value="인공지능">인공지능</option>
+            <option value="클라우드">클라우드</option>
+          </select>
+        </label>
+
+        <div className="generate__visibility">
+          <label>
+            <input
+              type="radio"
+              name="visibility"
+              value="public"
+              checked={visibility === 'public'}
+              onChange={() => setVisibility('public')}
+            />{' '}
+            <span className="generate__visibility-radio">
+            <p className="generate__visibility-radio-label">public</p>
+            <p className="generate__visibility-radio-desc">다른 사용자에게 공유됩니다.</p>
+            </span>
+          </label>
+          <label>
+            <input
+              type="radio"
+              name="visibility"
+              value="private"
+              checked={visibility === 'private'}
+              onChange={() => setVisibility('private')}
+            />{' '}
+            <span className="generate__visibility-radio">
+            <p className="generate__visibility-radio-label">private</p>
+            <p className="generate__visibility-radio-desc">다른 사용자에게 공유되지 않습니다.</p>
+            </span>
+          </label>
+        </div>
+
+        <button type="submit" className="generate__button">
+          생성하기
+        </button>
+      </form>
+    </div>
+  );
+};
+
+export default GenerateTILForm;

--- a/src/components/generate/generateTILForm/GenerateTILForm.tsx
+++ b/src/components/generate/generateTILForm/GenerateTILForm.tsx
@@ -12,19 +12,19 @@ const GenerateTILForm = () => {
 
   return (
     <div className="generate">
-    <form className="generate__form">
-    <label className='generate__label'>
-        선택된 커밋 목록
-      <section className="generate__commits">
-        <ul className="generate__commits-list">
-          {commitMessages.map((msg, index) => (
-              <li key={index} className="generate__commit-item">
-              {msg}
-            </li>
-          ))}
-        </ul>
-      </section>
-      </label>
+        <form className="generate__form">
+            <label className='generate__label'>
+                선택된 커밋 목록
+            <section className="generate__commits">
+                <ul className="generate__commits-list">
+                {commitMessages.map((msg, index) => (
+                    <li key={index} className="generate__commit-item">
+                    {msg}
+                    </li>
+                ))}
+                </ul>
+            </section>
+            </label>
 
         <label className="generate__label">
           TIL 제목

--- a/src/components/generate/generateTILForm/GenerateTILForm.tsx
+++ b/src/components/generate/generateTILForm/GenerateTILForm.tsx
@@ -2,10 +2,12 @@
 
 import './GenerateTILForm.scss';
 import { useCommitListStore } from '@/store/userCommitListStore';
+import { useSelectedCommitListStore } from '@/store/selectedCommitListStore';
 import { useState } from 'react';
 
 const GenerateTILForm = () => {
   const { commitMessages } = useCommitListStore();
+  const {selectedCommitMessages} = useSelectedCommitListStore();
   const [title, setTitle] = useState('');
   const [category, setCategory] = useState('풀스택');
   const [visibility, setVisibility] = useState<'public' | 'private'>('public');
@@ -17,7 +19,7 @@ const GenerateTILForm = () => {
                 선택된 커밋 목록
             <section className="generate__commits">
                 <ul className="generate__commits-list">
-                {commitMessages.map((msg, index) => (
+                {selectedCommitMessages.map((msg, index) => (
                     <li key={index} className="generate__commit-item">
                     {msg}
                     </li>

--- a/src/components/main/heatmap/Heatmap.tsx
+++ b/src/components/main/heatmap/Heatmap.tsx
@@ -17,7 +17,7 @@ import useGetAccessToken from '@/hooks/useGetAccessToken';
 const weekdays = ["Sun", "Mon", "Tues", "Wed", "Thur", "Fri", "Sat"];
 const currentDate = new Date();
 const basicYear = currentDate.getFullYear();
-const rawCurrentMonth = currentDate.getMonth(); // 0-based
+const rawCurrentMonth = currentDate.getMonth();
 const adjustedCurrentMonth = rawCurrentMonth >= 9 ? 8 : rawCurrentMonth;
 
 interface TilApiResponse {

--- a/src/store/selectedCommitListStore.tsx
+++ b/src/store/selectedCommitListStore.tsx
@@ -1,0 +1,13 @@
+import { create } from 'zustand';
+
+interface SelectedCommitListState {
+  selectedCommitMessages: string[];
+  setSelectedCommitMessages: (messages: string[]) => void;
+  resetSelectedCommitMessages: () => void;
+}
+
+export const useSelectedCommitListStore = create<SelectedCommitListState>((set) => ({
+  selectedCommitMessages: [],
+  setSelectedCommitMessages: (messages) => set({ selectedCommitMessages: messages }),
+  resetSelectedCommitMessages: () => set({ selectedCommitMessages: [] }),
+}));


### PR DESCRIPTION
## ✨ PR 개요

> 어떤 작업을 했는지 간단히 설명해주세요.

- feat: generate form 추가
- design: generate form 가로길이 수정
- design: 커밋 리스트 margin bottom 추가
- feat: 최대 5개까지의 커밋 선택 가능
- feat: 커밋 리스트와 선택된 커밋 리스트 분리

---

## 📋 변경사항

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [x] 스타일 수정
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 기타 (설명 필요)

---

## 🔥 작업 내용 상세

- feat: generate form 추가
  - generate form 추가, 선택한 커밋 목록 확인, til 제목, 카테고리, 공유 여부 입력 가능
- design: generate form 가로길이 수정
  - generate form의 가로길이가 지나치게 긴 것을 수정
- design: 커밋 리스트 margin bottom 추가
  - 커밋 리스트가 5개가 넘어갈 시 가장 마지막의 커밋 리스트가 보이지 않던것을 수정
- feat: 최대 5개까지의 커밋 선택 가능
  - 최대 5개 까지의 커밋 선택 가능, 그 이상으로 커밋을 선택하려고 하면 shake animation 추가
- feat: 커밋 리스트와 선택된 커밋 리스트 분리
  - 해당 날짜의 모든 커밋 리스트와 선택된 커밋 리스트를 분리하여 전역 저장소를 나눔

---

## 🎯 확인해야 할 것

- [x] PR 내용과 실제 코드가 일치하는가?
- [x] 빌드/배포에 영향이 없는가?
- [x] 테스트가 필요한 부분은 모두 테스트했는가?

---

## 📸 스크린샷 (선택)

> UI 변경사항이 있다면 첨부해주세요.

---

## ❗️ 기타 메모

> 참고해야 할 사항이나 이슈가 있으면 적어주세요.
