### PR TITLE
Fix: repository 페이지 til 리스트 수정 및 커밋 리스트 페이지 수정  

### DIFF
--- a/src/components/commit/linkGithubButton/LinkGithubButton.scss
+++ b/src/components/commit/linkGithubButton/LinkGithubButton.scss
@@ -1,17 +1,54 @@
 .link-github-button {
-    width: 200px;
-    height: 25px;
+  width: 200px;
+  height: 25px;
+  background-color: #00B6FA;
+  color: white;
+  font-size: 15px;
+  text-align: center;
+  border-radius: 12px;
+  cursor: pointer;
+  user-select: none;
+  transition: background-color 0.2s ease;
+  line-height: 25px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  &:hover {
+    background-color: #009ddc;
+  }
+
+  &__info {
+    font-size: 15px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  &__repo-name {
+    color: #00B6FA;
+    font-weight: 400;
+    text-align: center;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    max-width: 200px;
+    margin-left: 40px;
+  }
+
+  &__change {
+    margin-left: 12px;
+    padding: 2px 8px;
+    font-size: 13px;
     background-color: #00B6FA;
     color: white;
-    font-size: 15px;
-    text-align: center;
-    border-radius: 12px;
+    border: none;
+    border-radius: 4px;
     cursor: pointer;
-    user-select: none;
     transition: background-color 0.2s ease;
-  
+
     &:hover {
       background-color: #009ddc;
     }
   }
-  
+}

--- a/src/components/commit/linkGithubButton/LinkGithubButton.tsx
+++ b/src/components/commit/linkGithubButton/LinkGithubButton.tsx
@@ -6,10 +6,17 @@ import SelectRepositoryModal from '../selectRepositoryModal/SelectRepositoryModa
 import SelectBranchModal from '../selectBranchModal/SelectBranchModal';
 import './LinkGithubButton.scss';
 
+import { useUserRepositoryStore } from '@/store/userRepositoryStore';
+import { useSelectedDateStore } from '@/store/userDateStore';
+import { useUserBranchStore } from '@/store/userBranchStore';
+
 const LinkGithubButton = () => {
   const [organizationModalOpen, setOrganizationModalOpen] = useState(false);
   const [repositoryModalOpen, setRepositoryModalOpen] = useState(false);
   const [branchModalOpen, setBranchModalOpen] = useState(false);
+
+  const selectedRepo = useUserRepositoryStore((state) => state.selectedRepository);
+  const selectedBranchName = useUserBranchStore((state) => state.selectedBranch);
 
   const handleOpenOrganizationModal = () => {
     setOrganizationModalOpen(true);
@@ -39,9 +46,21 @@ const LinkGithubButton = () => {
 
   return (
     <>
-      <div className="link-github-button" onClick={handleOpenOrganizationModal}>
-        깃허브 연동하기
-      </div>
+      {selectedRepo && selectedBranchName ? (
+        <div className="link-github-button__info">
+          <span className="link-github-button__repo-name">{selectedRepo.repositoryName}</span>
+          <button
+            className="link-github-button__change"
+            onClick={handleOpenOrganizationModal}
+          >
+            변경
+          </button>
+        </div>
+      ) : (
+        <div className="link-github-button" onClick={handleOpenOrganizationModal}>
+          깃허브 연동하기
+        </div>
+      )}
 
       {organizationModalOpen && (
         <SelectOrganizationModal

--- a/src/components/commit/selectDateCalendar/SelectDateCalendar.tsx
+++ b/src/components/commit/selectDateCalendar/SelectDateCalendar.tsx
@@ -13,22 +13,25 @@ import {
   endOfWeek,
   isSameMonth,
   isSameDay,
-  addDays
+  addDays,
+  parseISO,
 } from 'date-fns';
 import './SelectDateCalendar.scss';
 import { useSelectedDateStore } from '@/store/userDateStore';
 
-
 const SelectDateCalendar = () => {
-  const [currentDate, setCurrentDate] = useState(new Date());
-  const [selectedDate, setSelectedDate] = useState(new Date());
+  const { selectedDate: storedDate, setSelectedDate } = useSelectedDateStore();
 
-  const setSelectedDateGlobal = useSelectedDateStore((state) => state.setSelectedDate);
+  const parsedStoredDate = storedDate ? parseISO(storedDate) : null;
+  const today = new Date();
+
+  const [currentDate, setCurrentDate] = useState(parsedStoredDate ?? today);
+  const [selectedDate, setSelectedDateLocal] = useState(parsedStoredDate ?? today);
 
   useEffect(() => {
     const formatted = format(selectedDate, 'yyyy-MM-dd');
-    setSelectedDateGlobal(formatted);
-  }, [selectedDate, setSelectedDateGlobal]);
+    setSelectedDate(formatted);
+  }, [selectedDate, setSelectedDate]);
 
   const renderHeader = () => (
     <div className="calendar__header">
@@ -74,7 +77,7 @@ const SelectDateCalendar = () => {
           <div
             className={`calendar__cell ${isSelected ? 'calendar__cell--selected' : ''} ${!isCurrentMonth ? 'calendar__cell--disabled' : ''}`}
             key={day.toISOString()}
-            onClick={() => setSelectedDate(cloneDay)}
+            onClick={() => setSelectedDateLocal(cloneDay)}
           >
             {format(day, 'd')}
           </div>

--- a/src/components/repository/til/RepositoryTILList.tsx
+++ b/src/components/repository/til/RepositoryTILList.tsx
@@ -46,11 +46,19 @@ const RepositoryTILList = () => {
     const fetchTILs = async () => {
       setIsLoading(true);
       setIsError(false);
+
+      const today = new Date();
+      const yyyy = today.getFullYear();
+      const mm = String(today.getMonth() + 1).padStart(2, '0');
+      const dd = String(today.getDate()).padStart(2, '0');
+      const formattedToday = `${yyyy}-${mm}-${dd}`;
+
+      const targetDate = tilDate || formattedToday;
+
       try {
-        console.log(tilDate);
         const response = await callApi<TILResponse>({
           method: 'GET',
-          endpoint: `/tils?page=0&size=10&date=${tilDate}`,
+          endpoint: `/tils?page=0&size=10&date=${targetDate}`,
           headers: {
             Authorization: `Bearer ${accessToken}`,
           },
@@ -61,7 +69,7 @@ const RepositoryTILList = () => {
         setIsError(true);
       } finally {
         setIsLoading(false);
-      } 
+      }
     };
 
     fetchTILs();
@@ -88,9 +96,6 @@ const RepositoryTILList = () => {
       console.error('TIL 상세 요청 실패:', error);
     }
   };
-
-  // if (isLoading) return <p className="repository-til-list__loading">로딩 중...</p>;
-  // if (isError) return <p className="repository-til-list__loading">불러오기 실패</p>;
 
   return (
     <div className="repository-til-list">


### PR DESCRIPTION
## ✨ PR 개요

> 어떤 작업을 했는지 간단히 설명해주세요.

- fix: repository til 리스트 fetch 형식 수정
- feat: 커밋 리스트 날짜 상태관리 추가 및 새로고침 버튼 삭제
- feat: 커밋 리스트 페이지, 현재 레포지토리 확인창 추가

---

## 📋 변경사항

- [x] 새로운 기능 추가
- [x] 버그 수정
- [ ] 스타일 수정
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 기타 (설명 필요)

---

## 🔥 작업 내용 상세

- fix: repository til 리스트 fetch 형식 수정
  - 새로고침 시 전역 상태관리에 저장 된 선택 날짜가 사라져서 모든 til 리스트를 받아오는 버그 수정
  - 이제는 새로고침 후 날짜가 없을 시 현재 날짜로 til 리스트를 받아오도록 수정 
- feat: 커밋 리스트 날짜 상태관리 추가 및 새로고침 버튼 삭제
  - 커밋 리스트 페이지 새로고침 버튼 삭제 후 달력에서 선택한 날짜별로 바로 커밋 리스트 받아옴 
- feat: 커밋 리스트 페이지, 현재 레포지토리 확인창 추가
  - 레포지토리와 브랜치를 선택했다면 "깃허브 연동 버튼" 대신 현재 선택한 레포지토리 이름이 나타나도록 변경
  - 레포지토리 이름 옆에 버튼을 추가하여 연결된 조직/레포지토리/브랜치 재설정 가능 
---
