### PR TITLE
fix: accessToken 만료 시 메인화면으로 라우팅

### DIFF
--- a/src/components/main/heatmap/Heatmap.tsx
+++ b/src/components/main/heatmap/Heatmap.tsx
@@ -59,6 +59,7 @@ const Heatmap = () => {
           headers: {
             Authorization: `Bearer ${accessToken}`,
           },
+          credentials: 'include',
         });
 
         const raw = res.data?.tils ?? {};

--- a/src/components/main/newTILList/NewTILList.tsx
+++ b/src/components/main/newTILList/NewTILList.tsx
@@ -39,6 +39,7 @@ const NewTILList = () => {
           headers: {
             Authorization: `Bearer ${accessToken}`,
           },
+          credentials: 'include',
         });
         setTils(response.data);
       } catch (error) {

--- a/src/hooks/useFetch.tsx
+++ b/src/hooks/useFetch.tsx
@@ -1,5 +1,6 @@
 import { useCallback } from 'react';
 import useAuthStore from '@/store/authStore';
+import Router from 'next/router';
 
 type HttpMethod = 'GET' | 'POST' | 'PUT' | 'DELETE';
 
@@ -42,6 +43,7 @@ export const useFetch = () => {
       const newAccessToken = response.headers.get('authorization')?.replace('Bearer ', '');
       if (newAccessToken) {
         setAccessToken(newAccessToken);
+        Router.push('/'); 
       }
 
       if (!response.ok) {


### PR DESCRIPTION
새로운 accessToken을 세팅하고 메인 화면으로 라우팅 추가
라우팅 된 메인화면에서는 description, newtil, heatmap, technews가 새롭게 발급받은 accessToken을 사용하여 fetch함